### PR TITLE
ci: switch to actions/attest for provenance

### DIFF
--- a/.github/actions/full-release/action.yml
+++ b/.github/actions/full-release/action.yml
@@ -25,11 +25,6 @@ inputs:
   token:
     description: 'The GitHub token to use for publishing documentation.'
     required: true
-outputs:
-  hashes:
-    description: sha256sum hashes of built artifacts
-    value: ${{ steps.publish.outputs.hashes }}
-
 runs:
   using: composite
   steps:

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -7,11 +7,6 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
-outputs:
-  hashes:
-    description: sha256sum hashes of built artifacts
-    value: ${{ steps.hash.outputs.hashes }}
-
 runs:
   using: composite
   steps:
@@ -41,13 +36,6 @@ runs:
           dotnet nuget push "${pkg}" --api-key ${{ env.NUGET_API_KEY }} --source https://www.nuget.org
           echo "published ${pkg}"
         done
-
-    - name: Hash nuget packages
-      id: hash
-      if: ${{ inputs.dry_run == 'false' }}
-      shell: bash
-      run: |
-        echo "hashes=$(sha256sum ./nupkgs/*.nupkg ./nupkgs/*.snupkg | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Dry Run Publish
       if: ${{ inputs.dry_run == 'true' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,11 +31,27 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      attestations: write
     if: ${{ needs.release-please.outputs.dotnet-sdk-internal-released == 'true'}}
-    outputs:
-      hashes: ${{ steps.full-release.outputs.hashes }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.dotnet-sdk-internal-tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
 
       - name: Setup Env from project's Env file
         shell: bash
@@ -53,15 +69,29 @@ jobs:
           aws_role: ${{ vars.AWS_ROLE_ARN }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  release-sdk-internal-provenance:
+      - name: Generate checksums file
+        env:
+          HASHES: ${{ steps.full-release.outputs.hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt
+
+  publish-release:
     needs: ['release-please', 'release-sdk-internal']
+    if: ${{ needs.release-please.outputs.dotnet-sdk-internal-released == 'true' }}
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
-      id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    with:
-      base64-subjects: "${{ needs.release-sdk-internal.outputs.hashes }}"
-      upload-assets: true
-      upload-tag-name: ${{ needs.release-please.outputs.dotnet-sdk-internal-tag_name }}
-      provenance-name: ${{ format('LaunchDarkly.InternalSDK-{0}_provenance.intoto.jsonl', needs.release-please.outputs.dotnet-sdk-internal-tag_name) }}
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.dotnet-sdk-internal-tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,13 +54,7 @@ jobs:
           aws_role: ${{ vars.AWS_ROLE_ARN }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate checksums file
-        env:
-          HASHES: ${{ steps.full-release.outputs.hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'nupkgs/*'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,21 +38,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-please.outputs.dotnet-sdk-internal-tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
       - name: Setup Env from project's Env file
         shell: bash
         run: echo "$(cat src/LaunchDarkly.InternalSdk/github_actions.env)" >> $GITHUB_ENV
@@ -79,19 +64,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['release-please', 'release-sdk-internal']
-    if: ${{ needs.release-please.outputs.dotnet-sdk-internal-released == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.dotnet-sdk-internal-tag_name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,6 @@ jobs:
 
     outputs:
       dotnet-sdk-internal-released: ${{ steps.release.outputs.release_created }}
-      dotnet-sdk-internal-tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Attest build provenance
         if: |
-          !inputs.dry_run && (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
+          inputs.dry_run == false && (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'
@@ -61,7 +61,8 @@ jobs:
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: >
-          gh release edit "${{ github.ref_name }}"
+          gh release edit "$TAG_NAME"
           --repo ${{ github.repository }}
           --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Attest build provenance
         if: |
-          inputs.dry_run == false && (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
+          format('{0}', inputs.dry_run) == 'false' && (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,20 +44,12 @@ jobs:
           aws_role: ${{ vars.AWS_ROLE_ARN }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate checksums file
-        if: |
-          !inputs.dry_run && (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
-        env:
-          HASHES: ${{ steps.full-release.outputs.hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: |
           !inputs.dry_run && (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'nupkgs/*'
 
   publish-release:
     needs: ['build']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
           - Default
           - Generate
           - Do not generate
+      publish_release:
+        description: 'Whether to publish (un-draft) a GitHub release after uploading artifacts.'
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -20,8 +24,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    outputs:
-      full-release-hashes: ${{ steps.full-release.outputs.hashes }}
+      attestations: write
     steps:
       - uses: actions/checkout@v4
 
@@ -41,16 +44,32 @@ jobs:
           aws_role: ${{ vars.AWS_ROLE_ARN }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  release-provenance:
+      - name: Generate checksums file
+        if: |
+          (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
+        env:
+          HASHES: ${{ steps.full-release.outputs.hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: |
+          (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt
+
+  publish-release:
     needs: ['build']
+    if: ${{ inputs.publish_release }}
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
-      id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    if: |
-      (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
-    with:
-      base64-subjects: "${{ needs.build.outputs.full-release-hashes }}"
-      upload-assets: true
-      provenance-name: src/LaunchDarkly.InternalSdk_provenance.intoto.jsonl
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          gh release edit "${{ github.ref_name }}"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate checksums file
         if: |
-          (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
+          !inputs.dry_run && (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
         env:
           HASHES: ${{ steps.full-release.outputs.hashes }}
         run: |
@@ -54,7 +54,7 @@ jobs:
 
       - name: Attest build provenance
         if: |
-          (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
+          !inputs.dry_run && (inputs.generate_provenance == 'Generate' || (inputs.generate_provenance == 'Default' && github.ref_name == 'main'))
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
   publish-release:
     needs: ['build']
-    if: ${{ inputs.publish_release }}
+    if: ${{ format('{0}', inputs.publish_release) == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying SDK build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=3.6.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.InternalSdk -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.InternalSdk.${SDK_VERSION}/LaunchDarkly.InternalSdk.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.InternalSdk.3.6.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-sdk-internal
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-sdk-internal
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ ddc934dc4dbcb14fc48c4d75ff5fc43ef3ed83f67fb20061a5ea83b656eded02
 Public Key Token: ff53908ab73043b6
 ```
 
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "force-tag-creation": true,
       "bump-minor-pre-major": true,
       "versioning": "default",
       "include-v-in-tag": false,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false,
       "extra-files": [
-        "src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj"
+        "src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj",
+        "PROVENANCE.md"
       ]
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "draft": true,
       "force-tag-creation": true,
       "bump-minor-pre-major": true,
       "versioning": "default",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     "packages": {
       ".": {
         "release-type": "simple",
+        "draft": true,
         "bump-minor-pre-major": true,
         "versioning": "default",
         "include-v-in-tag": false,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,16 +1,17 @@
 {
-    "bootstrap-sha": "c71af645b9b9f29b812dab341b43c556733af351",
-    "packages": {
-      ".": {
-        "release-type": "simple",
-        "draft": true,
-        "bump-minor-pre-major": true,
-        "versioning": "default",
-        "include-v-in-tag": false,
-        "include-component-in-tag": false,
-        "extra-files": [
-          "src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj"
-        ]
-      }
+  "bootstrap-sha": "c71af645b9b9f29b812dab341b43c556733af351",
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "draft": true,
+      "force-tag-creation": true,
+      "bump-minor-pre-major": true,
+      "versioning": "default",
+      "include-v-in-tag": false,
+      "include-component-in-tag": false,
+      "extra-files": [
+        "src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj"
+      ]
     }
   }
+}


### PR DESCRIPTION
## Summary

Migrates the release workflows to support GitHub's immutable releases feature by replacing the SLSA provenance generator with `actions/attest@v4`. Since this repo only uses attestation (no binary/artifact uploads to the release), draft releases are **not** needed — `actions/attest@v4` stores attestations via GitHub's attestation API rather than as release assets, so release-please can publish directly.

**Changes across 7 files:**

1. **`release-please-config.json`** — Normalized JSON indentation (4-space → 2-space) and added trailing newline. Added `PROVENANCE.md` to `extra-files`. No draft/force-tag-creation settings since this repo does not upload artifacts to releases.

2. **`.github/actions/publish-package/action.yml`** — Removed the `hashes` output and the "Hash nuget packages" step. These existed to produce base64-encoded checksums for the old SLSA generator and are no longer needed since attestation now uses `subject-path` to reference artifacts directly on disk.

3. **`.github/actions/full-release/action.yml`** — Removed the `hashes` output that forwarded the value from `publish-package`.

4. **`.github/workflows/release-please.yml`** (automated release flow):
   - Replaced the separate `release-sdk-internal-provenance` SLSA reusable workflow job with an inline `actions/attest@v4` step in the existing `release-sdk-internal` job, using `subject-path: 'nupkgs/*'`.
   - Added `attestations: write` permission and `fetch-depth: 0` to checkout.
   - Removed the `hashes` job output and dead `dotnet-sdk-internal-tag_name` output.

5. **`.github/workflows/release.yml`** (manual `workflow_dispatch` flow):
   - Replaced the separate `release-provenance` SLSA reusable workflow job with inline `actions/attest@v4` using `subject-path: 'nupkgs/*'`.
   - Added `attestations: write` permission; removed the `full-release-hashes` job output.
   - Added `publish_release` boolean input (default: `false`) and a `publish-release` job gated on it.
   - Added `format('{0}', inputs.dry_run) == 'false'` guard to the attestation step. The `format()` call coerces both real booleans (from `workflow_call`) and strings (from `workflow_dispatch`) to a string before comparison, ensuring reliable behavior regardless of trigger type.
   - `publish-release` job passes `github.ref_name` through a `TAG_NAME` env var (avoids script injection in `run:` blocks).

6. **`PROVENANCE.md`** — New file documenting how to verify build provenance using `gh attestation verify`, with NuGet download instructions and sample verification output.

7. **`README.md`** — Added "Verifying build provenance with the SLSA framework" section linking to `PROVENANCE.md`.

Both workflows now use `subject-path: 'nupkgs/*'` consistently, which lets `actions/attest@v4` read `.nupkg`/`.snupkg` files directly from disk — eliminating the old base64 encode/decode round-trip, the "Generate checksums file" step, and all hash-related outputs from the composite actions.

### Why no draft releases for this repo?

The old SLSA generator uploaded `.intoto.jsonl` provenance files as release assets (via `upload-assets: true`), which would fail under immutable releases. The new `actions/attest@v4` stores attestations via GitHub's attestation API instead — it does **not** modify the GitHub release. Since this repo has no other artifact uploads, release-please can publish the release directly without a draft→publish flow.

### Updates since last revision

- **Reverted split release-please pattern**: A two-pass release-please pattern (`skip-github-pull-request` / `skip-github-release`) was briefly added to this repo. That pattern is only needed for repos that upload artifacts to releases (which require draft releases). Since this repo is attestation-only, the standard single-pass release-please is correct and has been restored.
- **Added `PROVENANCE.md`**: Documents how to verify NuGet package provenance using `gh attestation verify --owner launchdarkly`, including download instructions and sample output.
- **Added README provenance section**: Links to `PROVENANCE.md` with the standard SLSA framework blurb.
- **Removed dead `tag_name` output**: The `dotnet-sdk-internal-tag_name` output on the `release-please` job was only consumed by the old SLSA generator job (now removed). Cleaned up as dead code.
- **Fixed `dry_run` condition for cross-trigger compatibility**: Changed from `inputs.dry_run == false` to `format('{0}', inputs.dry_run) == 'false'`. The `format()` call normalizes both real booleans (`workflow_call`) and strings (`workflow_dispatch`) to a string before comparison.
- **Fixed script injection in `publish-release` job**: `github.ref_name` is now passed through a `TAG_NAME` env var instead of being interpolated directly in the `run:` block.

## Review & Testing Checklist for Human

- [ ] **Verify `subject-path: 'nupkgs/*'` resolves correctly**: The composite action runs `dotnet pack --output nupkgs`, so `.nupkg` and `.snupkg` files should be in `./nupkgs/`. If the directory is empty or missing at attest time, the step will fail. In `release-please.yml` the entire job is gated on `dotnet-sdk-internal-released == 'true'`; in `release.yml` it's gated on `format('{0}', inputs.dry_run) == 'false'`.
- [ ] **`publish_release` defaults to `false` in `release.yml`**: Manual dispatches will *not* publish the release by default — the operator must opt in. Confirm this is the intended behavior (other repos in this migration default to `true`).
- [ ] **Confirm no downstream consumers of old `.intoto.jsonl` provenance files**: The old SLSA generator uploaded `LaunchDarkly.InternalSDK-{tag}_provenance.intoto.jsonl` as a release asset. Attestations now live in GitHub's attestation API instead.
- [ ] **End-to-end test**: Trigger a manual dispatch of `release.yml` with `dry_run: true` to verify attestation is skipped. Then test with `dry_run: false` and `generate_provenance: Generate` to verify `subject-path: 'nupkgs/*'` resolves and attestation succeeds. These changes cannot be validated by CI alone.

### Notes
- The `generate_provenance` conditional logic from the old SLSA job is preserved on the attest step in `release.yml`, now combined with the `format('{0}', inputs.dry_run) == 'false'` guard.
- The attestation step in `release-please.yml` runs unconditionally within the `release-sdk-internal` job, which is itself gated on `dotnet-sdk-internal-released == 'true'`.
- Kept `publish_release` input and `publish-release` job in `release.yml` (manual workflow) for cases where an operator needs to un-draft a release.
- The `PROVENANCE.md` version placeholder (`3.6.0`) is tracked by `x-release-please-start-version` markers and will be updated automatically on future releases.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84