### PR TITLE
ci: split release-please into independent release and PR creation steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,11 +16,41 @@ jobs:
       dotnet-sdk-internal-released: ${{ steps.release.outputs.release_created }}
 
     steps:
+      # Create any releases first, then create tags, and then optionally create any new PRs.
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}
+          skip-github-pull-request: true
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: ${{ github.ref_name }}
+          skip-github-release: true
 
   release-sdk-internal:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

Splits the single `release-please-action` call into two independent passes to support GitHub's immutable releases:

1. **First pass** (`skip-github-pull-request: true`): Creates releases only. If a release is created, the tag is created inline via `git tag` + `git push` before any downstream jobs run.
2. **Second pass** (`skip-github-release: true`, only if no release was created): Creates/updates release PRs only.

This ensures release-please doesn't attempt to re-create a PR when it sees a tag already exists, which would otherwise happen because the tag creation and PR management were previously coupled in a single action invocation. Follows the same pattern established in [ld-relay PR #622](https://github.com/launchdarkly/ld-relay/pull/622).

## Review & Testing Checklist for Human

- [ ] Verify the `release_created` (singular) output used in tag-creation conditions aligns with the job output `dotnet-sdk-internal-released: ${{ steps.release.outputs.release_created }}` — both reference the same step output, but confirm release-please emits this correctly when `skip-github-pull-request: true` is set
- [ ] Confirm the `release-sdk-internal` downstream job still triggers correctly — it depends on `needs.release-please.outputs.dotnet-sdk-internal-released`, which hasn't changed structurally
- [ ] Test a dry run: trigger the workflow on a non-main branch (via `workflow_dispatch`) to verify the second pass (PR creation) runs when no release is created

### Notes
- The tag creation step uses `gh api` to check for existing tags before creating, avoiding duplicate tag errors
- No changes to downstream jobs or permissions — only the `release-please` job steps are modified

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation flow and introduces manual tag creation/push, which could affect release correctness if `release_created`/`tag_name` outputs or permissions differ from expectations, but scope is limited to a single workflow.
> 
> **Overview**
> Refactors the `release-please` GitHub Actions workflow to **decouple GitHub Release creation from release PR management**.
> 
> The first `release-please` run now creates releases only (`skip-github-pull-request: true`); when a release is created, the workflow checks out the repo and **creates/pushes the release tag** (skipping if it already exists). If no release is created, a second `release-please` invocation runs in *PR-only* mode (`skip-github-release: true`) to create/update release PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7180de3231d4d2efb04866983c98d0cb4268d0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->