### PR TITLE
fix: Update CommonSdk to 7.2.0

### DIFF
--- a/src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj
+++ b/src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="[7.1.1,8.0.0)" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="[7.2.0,8.0.0)" />
     <PackageReference Include="LaunchDarkly.Logging" Version="[2.0.0,3.0.0)" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Bumps the minimum `LaunchDarkly.CommonSdk` dependency from `7.1.1` to `7.2.0`. The version range upper bound (`< 8.0.0`) is unchanged.

A companion PR in `launchdarkly/dotnet-core` makes the same update for the Server SDK and Client SDK packages.

## Review & Testing Checklist for Human

- [ ] Verify that `LaunchDarkly.CommonSdk` 7.2.0 is published on NuGet and contains no breaking API changes that would affect `InternalSdk`
- [ ] Confirm CI builds and tests pass against the new minimum version

### Notes

Single-line change in `LaunchDarkly.InternalSdk.csproj`. Version range format `[7.2.0,8.0.0)` is consistent with the existing convention.

Link to Devin session: https://app.devin.ai/sessions/02ea0cc05e4945aa8302e415648ca371
Requested by: @jsonbailey

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump that only raises the minimum allowed `LaunchDarkly.CommonSdk` version; behavior changes depend on upstream 7.2.0 contents.
> 
> **Overview**
> Updates `LaunchDarkly.InternalSdk`’s NuGet dependency constraint for `LaunchDarkly.CommonSdk` from `[7.1.1,8.0.0)` to `[7.2.0,8.0.0)`, keeping the same `< 8.0.0` upper bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eaac1557d489d7a4386870c88a9c649b2d87f0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->