### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`.

The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml` was updated to declare `permissions: pull-requests: read` at the job level. A reusable workflow can only request a subset of the permissions the caller grants, so callers without an explicit `permissions` block now cause a `startup_failure`. This adds the required permission.

Same fix as [launchdarkly/sdk-meta#429](https://github.com/launchdarkly/sdk-meta/pull/429), applied across SDK repositories.

## Review & Testing Checklist for Human

- [ ] Verify the `Lint PR title` check on this PR itself passes (rather than hitting `startup_failure`)

### Notes

Identical change is being applied across all SDK repos that use the `launchdarkly/gh-actions` reusable lint-pr-title workflow. `php-server-sdk-otel` was skipped due to a push permission issue.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a minimal GitHub Actions permission change scoped to read-only access on pull requests.
> 
> **Overview**
> Ensures the `Lint PR title` workflow can run by adding an explicit workflow-level `permissions: pull-requests: read` to `.github/workflows/lint-pr-title.yml`, satisfying the permissions required by the referenced reusable workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99edba7a279be1096fbb2e73ba756144e7caea53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->