### PR TITLE
feat: add optional support for per-context summary events

### DIFF
--- a/src/LaunchDarkly.InternalSdk/Events/AggregatedEventSummarizer.cs
+++ b/src/LaunchDarkly.InternalSdk/Events/AggregatedEventSummarizer.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace LaunchDarkly.Sdk.Internal.Events
+{
+    /// <summary>
+    /// Produces a single aggregated summary event covering all contexts, with no context attached.
+    /// This is the original summarization behavior and the default; it is used by server-side SDKs.
+    /// </summary>
+    /// <remarks>
+    /// Not thread-safe; always invoked from the event processor's single message-processing thread.
+    /// </remarks>
+    internal sealed class AggregatedEventSummarizer : IEventSummarizer
+    {
+        private readonly EventSummarizer _summarizer = new EventSummarizer();
+
+        public void SummarizeEvent(
+            UnixMillisecondTime timestamp,
+            string flagKey,
+            int? flagVersion,
+            int? variation,
+            in LdValue value,
+            in LdValue defaultValue,
+            in Context context
+            ) =>
+            _summarizer.SummarizeEvent(timestamp, flagKey, flagVersion, variation, value, defaultValue, context);
+
+        public IReadOnlyList<EventSummary> GetSummariesAndReset()
+        {
+            EventSummary summary = _summarizer.GetSummaryAndReset();
+            return summary.Empty ? Array.Empty<EventSummary>() : new[] { summary };
+        }
+
+        public void Clear() => _summarizer.Clear();
+    }
+}

--- a/src/LaunchDarkly.InternalSdk/Events/EventOutput.cs
+++ b/src/LaunchDarkly.InternalSdk/Events/EventOutput.cs
@@ -17,13 +17,13 @@ namespace LaunchDarkly.Sdk.Internal.Events
             _contextFormatter = new EventContextFormatter(config);
         }
 
-        public byte[] SerializeOutputEvents(object[] events, EventSummary summary, out int eventCountOut)
+        public byte[] SerializeOutputEvents(object[] events, IReadOnlyList<EventSummary> summaries, out int eventCountOut)
         {
             using (var stream = new MemoryStream())
             {
                 using (var jsonWriter = new Utf8JsonWriter(stream))
                 {
-                    eventCountOut = WriteOutputEvents(events, summary, jsonWriter);
+                    eventCountOut = WriteOutputEvents(events, summaries, jsonWriter);
                     jsonWriter.Flush();
                     return stream.ToArray();
                 }
@@ -39,7 +39,7 @@ namespace LaunchDarkly.Sdk.Internal.Events
                 new MutableKeyValuePair<A, B> {Key = kv.Key, Value = kv.Value};
         }
 
-        public int WriteOutputEvents(object[] events, EventSummary summary, Utf8JsonWriter w)
+        public int WriteOutputEvents(object[] events, IReadOnlyList<EventSummary> summaries, Utf8JsonWriter w)
         {
             var eventCount = events.Length;
             w.WriteStartArray();
@@ -48,10 +48,13 @@ namespace LaunchDarkly.Sdk.Internal.Events
                 WriteOutputEvent(e, w);
             }
 
-            if (!summary.Empty)
+            foreach (var summary in summaries)
             {
-                WriteSummaryEvent(summary, w);
-                eventCount++;
+                if (!summary.Empty)
+                {
+                    WriteSummaryEvent(summary, w);
+                    eventCount++;
+                }
             }
 
             w.WriteEndArray();
@@ -122,6 +125,13 @@ namespace LaunchDarkly.Sdk.Internal.Events
             w.WriteString("kind", "summary");
             w.WriteNumber("startDate", summary.StartDate.Value);
             w.WriteNumber("endDate", summary.EndDate.Value);
+
+            // Per-context summaries carry the evaluation context; aggregated summaries leave it
+            // undefined and omit it. The context is filtered the same way as for other events.
+            if (summary.Context.Defined)
+            {
+                WriteContext(summary.Context, w, redactAnonymous: true);
+            }
 
             w.WriteStartObject("features");
 

--- a/src/LaunchDarkly.InternalSdk/Events/EventProcessorInternal.cs
+++ b/src/LaunchDarkly.InternalSdk/Events/EventProcessorInternal.cs
@@ -102,23 +102,25 @@ namespace LaunchDarkly.Sdk.Internal.Events
         internal struct FlushPayload
         {
             internal object[] Events { get; set; }
-            internal EventSummary Summary { get; set; }
+            internal IReadOnlyList<EventSummary> Summaries { get; set; }
         }
 
         internal sealed class EventBuffer
         {
             private readonly List<object> _events;
-            private readonly EventSummarizer _summarizer;
+            private readonly IEventSummarizer _summarizer;
             private readonly IDiagnosticStore _diagnosticStore;
             private readonly int _capacity;
             private readonly Logger _logger;
             private bool _exceededCapacity;
 
-            internal EventBuffer(int capacity, IDiagnosticStore diagnosticStore, Logger logger)
+            internal EventBuffer(int capacity, bool perContextSummaries, IDiagnosticStore diagnosticStore, Logger logger)
             {
                 _capacity = capacity;
                 _events = new List<object>();
-                _summarizer = new EventSummarizer();
+                _summarizer = perContextSummaries
+                    ? (IEventSummarizer)new PerContextEventSummarizer()
+                    : new AggregatedEventSummarizer();
                 _diagnosticStore = diagnosticStore;
                 _logger = logger;
             }
@@ -146,7 +148,7 @@ namespace LaunchDarkly.Sdk.Internal.Events
                     ee.Context);
 
             internal FlushPayload GetPayload() =>
-                new FlushPayload { Events = _events.ToArray(), Summary = _summarizer.Snapshot() };
+                new FlushPayload { Events = _events.ToArray(), Summaries = _summarizer.GetSummariesAndReset() };
 
             internal void Clear()
             {
@@ -193,7 +195,8 @@ namespace LaunchDarkly.Sdk.Internal.Events
             _eventSender = eventSender;
             _logger = logger;
 
-            EventBuffer buffer = new EventBuffer(config.EventCapacity > 0 ? config.EventCapacity : 1, _diagnosticStore, _logger);
+            EventBuffer buffer = new EventBuffer(config.EventCapacity > 0 ? config.EventCapacity : 1,
+                config.PerContextSummaries, _diagnosticStore, _logger);
 
             // Here we use TaskFactory.StartNew instead of Task.Run() because that allows us to specify the
             // LongRunning option. This option tells the task scheduler that the task is likely to hang on
@@ -390,7 +393,7 @@ namespace LaunchDarkly.Sdk.Internal.Events
             {
                 _diagnosticStore.RecordEventsInBatch(payload.Events.Length);
             }
-            if (payload.Events.Length > 0 || !payload.Summary.Empty)
+            if (payload.Events.Length > 0 || payload.Summaries.Count > 0)
             {
                 lock (_flushWorkersCounter)
                 {
@@ -434,7 +437,7 @@ namespace LaunchDarkly.Sdk.Internal.Events
             int eventCount;
             try
             {
-                jsonEvents = formatter.SerializeOutputEvents(payload.Events, payload.Summary, out eventCount);
+                jsonEvents = formatter.SerializeOutputEvents(payload.Events, payload.Summaries, out eventCount);
             }
             catch (Exception e)
             {

--- a/src/LaunchDarkly.InternalSdk/Events/EventSummarizer.cs
+++ b/src/LaunchDarkly.InternalSdk/Events/EventSummarizer.cs
@@ -2,13 +2,21 @@
 
 namespace LaunchDarkly.Sdk.Internal.Events
 {
+    // Accumulates summary counters for a single context. The aggregated and per-context
+    // summarizers are both built on top of this. For the aggregated case the context is
+    // undefined and is not included in the output; for the per-context case each instance
+    // owns the context whose evaluations it summarizes.
     internal sealed class EventSummarizer
     {
+        private readonly Context _context;
         private EventSummary _eventsState;
 
-        public EventSummarizer()
+        public EventSummarizer() : this(default) { }
+
+        public EventSummarizer(Context context)
         {
-            _eventsState = new EventSummary();
+            _context = context;
+            _eventsState = new EventSummary(context);
         }
 
         // Adds this event to our counters, if it is a type of event we need to count.
@@ -26,17 +34,19 @@ namespace LaunchDarkly.Sdk.Internal.Events
             _eventsState.NoteTimestamp(timestamp);
         }
 
-        // Returns the current summarized event data.
-        public EventSummary Snapshot()
+        public bool Empty => _eventsState.Empty;
+
+        // Returns the current summarized event data and resets the state to empty.
+        public EventSummary GetSummaryAndReset()
         {
             EventSummary ret = _eventsState;
-            _eventsState = new EventSummary();
+            _eventsState = new EventSummary(_context);
             return ret;
         }
 
         public void Clear()
         {
-            _eventsState = new EventSummary();
+            _eventsState = new EventSummary(_context);
         }
     }
 
@@ -45,10 +55,21 @@ namespace LaunchDarkly.Sdk.Internal.Events
         public readonly Dictionary<string, FlagSummary> Flags =
             new Dictionary<string, FlagSummary>();
 
+        // The context whose evaluations this summary describes, or an undefined context for an
+        // aggregated summary. When defined, it is serialized onto the summary event.
+        public Context Context { get; }
+
         public UnixMillisecondTime StartDate { get; private set; }
         public UnixMillisecondTime EndDate { get; private set; }
 
         public bool Empty => Flags.Count == 0;
+
+        public EventSummary() { }
+
+        public EventSummary(Context context)
+        {
+            Context = context;
+        }
 
         public void IncrementCounter(string key, int? variation, int? version, LdValue flagValue, LdValue defaultVal, in Context context)
         {

--- a/src/LaunchDarkly.InternalSdk/Events/EventsConfiguration.cs
+++ b/src/LaunchDarkly.InternalSdk/Events/EventsConfiguration.cs
@@ -41,5 +41,15 @@ namespace LaunchDarkly.Sdk.Internal.Events
         public IImmutableSet<AttributeRef> PrivateAttributes { get; set;  }
 
         public TimeSpan? RetryInterval { get; set; }
+
+        /// <summary>
+        /// True if the events system should emit a separate summary event for each evaluation
+        /// context, with the context attached, instead of a single aggregated summary.
+        /// </summary>
+        /// <remarks>
+        /// Client-side SDKs enable this. Server-side SDKs leave it at the default of false, which
+        /// preserves the original single aggregated summary behavior.
+        /// </remarks>
+        public bool PerContextSummaries { get; set; }
     }
 }

--- a/src/LaunchDarkly.InternalSdk/Events/IEventSummarizer.cs
+++ b/src/LaunchDarkly.InternalSdk/Events/IEventSummarizer.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace LaunchDarkly.Sdk.Internal.Events
+{
+    /// <summary>
+    /// Strategy for summarizing evaluation events into summary events.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Implementations provide either a single aggregated summary covering all contexts, or one
+    /// summary per context with the context attached. The behavior is selected by the events
+    /// configuration so that client-side and server-side SDKs can differ without changing the
+    /// rest of the event pipeline.
+    /// </para>
+    /// <para>
+    /// Implementations are deliberately not thread-safe; they are always invoked from the event
+    /// processor's single message-processing thread.
+    /// </para>
+    /// </remarks>
+    internal interface IEventSummarizer
+    {
+        // Adds information about an evaluation to the summary.
+        void SummarizeEvent(
+            UnixMillisecondTime timestamp,
+            string flagKey,
+            int? flagVersion,
+            int? variation,
+            in LdValue value,
+            in LdValue defaultValue,
+            in Context context
+            );
+
+        // Returns the current summary data and resets the state to empty. The aggregated
+        // implementation returns at most one summary; the per-context implementation returns one
+        // per context that had events. Empty summaries are not included.
+        IReadOnlyList<EventSummary> GetSummariesAndReset();
+
+        // Discards all accumulated summary data.
+        void Clear();
+    }
+}

--- a/src/LaunchDarkly.InternalSdk/Events/PerContextEventSummarizer.cs
+++ b/src/LaunchDarkly.InternalSdk/Events/PerContextEventSummarizer.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace LaunchDarkly.Sdk.Internal.Events
+{
+    /// <summary>
+    /// Produces a separate summary event for each context, with the context attached, so that
+    /// analytics can attribute evaluations to specific contexts. This is used by client-side SDKs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A separate <see cref="EventSummarizer"/> is maintained per context. Contexts are used
+    /// directly as dictionary keys; <see cref="Context"/> provides value-based equality and hashing
+    /// over all of its attributes, so two contexts map to the same summary only when every attribute
+    /// matches.
+    /// </para>
+    /// <para>
+    /// Not thread-safe; always invoked from the event processor's single message-processing thread.
+    /// </para>
+    /// </remarks>
+    internal sealed class PerContextEventSummarizer : IEventSummarizer
+    {
+        private readonly Dictionary<Context, EventSummarizer> _summarizersByContext =
+            new Dictionary<Context, EventSummarizer>();
+
+        public void SummarizeEvent(
+            UnixMillisecondTime timestamp,
+            string flagKey,
+            int? flagVersion,
+            int? variation,
+            in LdValue value,
+            in LdValue defaultValue,
+            in Context context
+            )
+        {
+            if (!_summarizersByContext.TryGetValue(context, out var summarizer))
+            {
+                summarizer = new EventSummarizer(context);
+                _summarizersByContext[context] = summarizer;
+            }
+            summarizer.SummarizeEvent(timestamp, flagKey, flagVersion, variation, value, defaultValue, context);
+        }
+
+        public IReadOnlyList<EventSummary> GetSummariesAndReset()
+        {
+            var summaries = new List<EventSummary>();
+            foreach (var summarizer in _summarizersByContext.Values)
+            {
+                EventSummary summary = summarizer.GetSummaryAndReset();
+                if (!summary.Empty)
+                {
+                    summaries.Add(summary);
+                }
+            }
+            _summarizersByContext.Clear();
+            return summaries;
+        }
+
+        public void Clear() => _summarizersByContext.Clear();
+    }
+}

--- a/test/LaunchDarkly.InternalSdk.Tests/Events/AggregatedEventSummarizerTest.cs
+++ b/test/LaunchDarkly.InternalSdk.Tests/Events/AggregatedEventSummarizerTest.cs
@@ -1,0 +1,44 @@
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Internal.Events
+{
+    public class AggregatedEventSummarizerTest
+    {
+        private static readonly UnixMillisecondTime Time = UnixMillisecondTime.OfMillis(1000);
+        private static readonly Context ContextA = Context.New(ContextKind.Of("user"), "a");
+        private static readonly Context ContextB = Context.New(ContextKind.Of("user"), "b");
+
+        [Fact]
+        public void EmptySummarizerReturnsNoSummaries()
+        {
+            var summarizer = new AggregatedEventSummarizer();
+            Assert.Empty(summarizer.GetSummariesAndReset());
+        }
+
+        [Fact]
+        public void AllContextsAreAggregatedIntoASingleContextlessSummary()
+        {
+            var summarizer = new AggregatedEventSummarizer();
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("a"), LdValue.Null, ContextA);
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("b"), LdValue.Null, ContextB);
+
+            var summaries = summarizer.GetSummariesAndReset();
+
+            Assert.Single(summaries);
+            // No context is attached to an aggregated summary.
+            Assert.False(summaries[0].Context.Defined);
+            // Both evaluations are merged under the same flag/variation/version counter.
+            Assert.Equal(2, summaries[0].Flags["flag"].Counters[new EventsCounterKey(1, 0)].Count);
+        }
+
+        [Fact]
+        public void GetSummariesAndResetClearsState()
+        {
+            var summarizer = new AggregatedEventSummarizer();
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("a"), LdValue.Null, ContextA);
+
+            Assert.Single(summarizer.GetSummariesAndReset());
+            Assert.Empty(summarizer.GetSummariesAndReset());
+        }
+    }
+}

--- a/test/LaunchDarkly.InternalSdk.Tests/Events/EventOutputTest.cs
+++ b/test/LaunchDarkly.InternalSdk.Tests/Events/EventOutputTest.cs
@@ -205,13 +205,16 @@ namespace LaunchDarkly.Sdk.Internal.Events
             summary.NoteTimestamp(UnixMillisecondTime.OfMillis(1002));
 
             var f = new EventOutputFormatter(new EventsConfiguration());
-            var outputEvent = TestUtil.TryParseJson(f.SerializeOutputEvents(new object[0], summary, out var count))
+            var outputEvent = TestUtil.TryParseJson(f.SerializeOutputEvents(new object[0], new[] { summary }, out var count))
                 .Get(0);
             Assert.Equal(1, count);
 
             Assert.Equal("summary", outputEvent.Get("kind").AsString);
             Assert.Equal(1000, outputEvent.Get("startDate").AsInt);
             Assert.Equal(1002, outputEvent.Get("endDate").AsInt);
+
+            // An aggregated summary (undefined context) does not include a context.
+            Assert.Equal(LdValue.Null, outputEvent.Get("context"));
 
             var featuresJson = outputEvent.Get("features");
             Assert.Equal(3, featuresJson.Count);
@@ -239,6 +242,23 @@ namespace LaunchDarkly.Sdk.Internal.Events
                 thirdJson.Get("contextKinds")); // we evaluated this flag with only context2
             TestUtil.AssertContainsInAnyOrder(thirdJson.Get("counters").AsList(LdValue.Convert.Json),
                 LdValue.Parse(@"{""unknown"":true,""value"":""default3"",""count"":1}"));
+        }
+
+        [Fact]
+        public void PerContextSummaryEventIncludesTheContext()
+        {
+            var summary = new EventSummary(SimpleContext);
+            summary.NoteTimestamp(UnixMillisecondTime.OfMillis(1000));
+            summary.IncrementCounter("flag", 1, 11, LdValue.Of("value"), LdValue.Of("default"), SimpleContext);
+
+            var f = new EventOutputFormatter(new EventsConfiguration());
+            var outputEvent = TestUtil.TryParseJson(f.SerializeOutputEvents(new object[0], new[] { summary }, out var count))
+                .Get(0);
+
+            Assert.Equal(1, count);
+            Assert.Equal("summary", outputEvent.Get("kind").AsString);
+            Assert.Equal(LdValue.Parse(SimpleContextJson), outputEvent.Get("context"));
+            Assert.NotEqual(LdValue.Null, outputEvent.Get("features").Get("flag"));
         }
 
         [Fact]
@@ -731,8 +751,7 @@ namespace LaunchDarkly.Sdk.Internal.Events
 
         private LdValue SerializeOneEvent(EventOutputFormatter f, object e)
         {
-            var emptySummary = new EventSummary();
-            var json = f.SerializeOutputEvents(new object[] {e}, emptySummary, out var count);
+            var json = f.SerializeOutputEvents(new object[] {e}, new EventSummary[0], out var count);
             var outputEvent = TestUtil.TryParseJson(json).Get(0);
             Assert.Equal(1, count);
             return outputEvent;

--- a/test/LaunchDarkly.InternalSdk.Tests/Events/EventSummarizerTest.cs
+++ b/test/LaunchDarkly.InternalSdk.Tests/Events/EventSummarizerTest.cs
@@ -17,7 +17,7 @@ namespace LaunchDarkly.Sdk.Internal.Events
             es.SummarizeEvent(time2, "flag", null, null, LdValue.Null, LdValue.Null, _context);
             es.SummarizeEvent(time1, "flag", null, null, LdValue.Null, LdValue.Null, _context);
             es.SummarizeEvent(time3, "flag", null, null, LdValue.Null, LdValue.Null, _context);
-            EventSummary data = es.Snapshot();
+            EventSummary data = es.GetSummaryAndReset();
 
             Assert.Equal(time1, data.StartDate);
             Assert.Equal(time3, data.EndDate);
@@ -40,7 +40,7 @@ namespace LaunchDarkly.Sdk.Internal.Events
             es.SummarizeEvent(time, flag2Key, flag2Version, variation1, value99, default2, _context);
             es.SummarizeEvent(time, flag1Key, flag1Version, variation1, value1, default1, _context);
             es.SummarizeEvent(time, unknownFlagKey, null, null, default3, default3, _context);
-            EventSummary data = es.Snapshot();
+            EventSummary data = es.GetSummaryAndReset();
 
             Dictionary<EventsCounterKey, EventsCounterValue> expected = new Dictionary<EventsCounterKey, EventsCounterValue>();
             Assert.Equal(new EventsCounterValue(2, value1),
@@ -72,7 +72,7 @@ namespace LaunchDarkly.Sdk.Internal.Events
             es.SummarizeEvent(time, flag2Key, version, variation, value, value, c1);
             es.SummarizeEvent(time, flag2Key, version, variation, value, value, c2);
             es.SummarizeEvent(time, flag3Key, version, variation, value, value, multi);
-            EventSummary data = es.Snapshot();
+            EventSummary data = es.GetSummaryAndReset();
 
             Assert.Equal(new HashSet<string> { "kind1" }, data.Flags[flag1Key].ContextKinds);
             Assert.Equal(new HashSet<string> { "kind1", "kind2" }, data.Flags[flag2Key].ContextKinds);

--- a/test/LaunchDarkly.InternalSdk.Tests/Events/PerContextEventSummarizerTest.cs
+++ b/test/LaunchDarkly.InternalSdk.Tests/Events/PerContextEventSummarizerTest.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Internal.Events
+{
+    public class PerContextEventSummarizerTest
+    {
+        private static readonly UnixMillisecondTime Time = UnixMillisecondTime.OfMillis(1000);
+        private static readonly Context ContextA = Context.New(ContextKind.Of("user"), "a");
+        private static readonly Context ContextB = Context.New(ContextKind.Of("user"), "b");
+
+        private static EventSummary SummaryFor(IReadOnlyList<EventSummary> summaries, Context context) =>
+            summaries.Single(s => s.Context.Equals(context));
+
+        [Fact]
+        public void EmptySummarizerReturnsNoSummaries()
+        {
+            var summarizer = new PerContextEventSummarizer();
+            Assert.Empty(summarizer.GetSummariesAndReset());
+        }
+
+        [Fact]
+        public void EachContextGetsItsOwnSummaryWithTheContextAttached()
+        {
+            var summarizer = new PerContextEventSummarizer();
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("a"), LdValue.Null, ContextA);
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("b"), LdValue.Null, ContextB);
+
+            var summaries = summarizer.GetSummariesAndReset();
+
+            Assert.Equal(2, summaries.Count);
+            Assert.Equal(ContextA, SummaryFor(summaries, ContextA).Context);
+            Assert.Equal(ContextB, SummaryFor(summaries, ContextB).Context);
+        }
+
+        [Fact]
+        public void EvaluationsForEqualContextsAreMergedIntoOneSummary()
+        {
+            // Two distinct Context instances that are value-equal must map to the same accumulator.
+            var contextA1 = Context.New(ContextKind.Of("user"), "a");
+            var contextA2 = Context.New(ContextKind.Of("user"), "a");
+
+            var summarizer = new PerContextEventSummarizer();
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("v"), LdValue.Null, contextA1);
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("v"), LdValue.Null, contextA2);
+
+            var summaries = summarizer.GetSummariesAndReset();
+
+            Assert.Single(summaries);
+            var counter = summaries[0].Flags["flag"].Counters[new EventsCounterKey(1, 0)];
+            Assert.Equal(2, counter.Count);
+        }
+
+        [Fact]
+        public void ContextsDifferingByAttributeAreTrackedSeparately()
+        {
+            // Same key/kind but different attributes must be treated as different contexts.
+            var plain = Context.New(ContextKind.Of("user"), "a");
+            var withName = Context.Builder("a").Kind("user").Name("Pat").Build();
+
+            var summarizer = new PerContextEventSummarizer();
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("v"), LdValue.Null, plain);
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("v"), LdValue.Null, withName);
+
+            var summaries = summarizer.GetSummariesAndReset();
+
+            Assert.Equal(2, summaries.Count);
+        }
+
+        [Fact]
+        public void CountersAreAccumulatedPerContext()
+        {
+            var summarizer = new PerContextEventSummarizer();
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("a"), LdValue.Null, ContextA);
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("a"), LdValue.Null, ContextA);
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("b"), LdValue.Null, ContextB);
+
+            var summaries = summarizer.GetSummariesAndReset();
+
+            Assert.Equal(2, SummaryFor(summaries, ContextA).Flags["flag"].Counters[new EventsCounterKey(1, 0)].Count);
+            Assert.Equal(1, SummaryFor(summaries, ContextB).Flags["flag"].Counters[new EventsCounterKey(1, 0)].Count);
+        }
+
+        [Fact]
+        public void GetSummariesAndResetClearsState()
+        {
+            var summarizer = new PerContextEventSummarizer();
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("a"), LdValue.Null, ContextA);
+
+            Assert.Single(summarizer.GetSummariesAndReset());
+            Assert.Empty(summarizer.GetSummariesAndReset());
+        }
+
+        [Fact]
+        public void ClearDiscardsAccumulatedData()
+        {
+            var summarizer = new PerContextEventSummarizer();
+            summarizer.SummarizeEvent(Time, "flag", 1, 0, LdValue.Of("a"), LdValue.Null, ContextA);
+
+            summarizer.Clear();
+
+            Assert.Empty(summarizer.GetSummariesAndReset());
+        }
+    }
+}


### PR DESCRIPTION
SDK-2449

## What

Adds an opt-in per-context summary event mode to the shared events implementation. When enabled, the events system emits one `summary` event per evaluation context — with the context attached — instead of a single aggregated summary. This supports the Client-Side Summary Events (CSSE) spec and the "who got what when" analytics it enables.

`LaunchDarkly.InternalSdk` is shared by both the server and client SDKs, so this is **opt-in and default-off**: server-side runtime behavior and wire output are unchanged. The client SDK will enable it in a follow-up PR.

## How

- New `IEventSummarizer` interface with two implementations:
  - `AggregatedEventSummarizer` — wraps the existing single-context accumulator and returns at most one summary with no context. **Default; current server behavior.**
  - `PerContextEventSummarizer` — keeps one accumulator per context, keyed directly by `Context` (its value-based `Equals`/`GetHashCode` cover all attributes), and returns one summary per context.
- `EventsConfiguration.PerContextSummaries` flag (default `false`) selects the implementation in `EventBuffer`.
- `EventSummary` gains an (undefined-by-default) `Context`; the flush payload and `EventOutputFormatter` now carry/serialize a list of summaries, writing the event-filtered context (`redactAnonymous: true`) only when defined.

## Reference

Mirrors the Java implementation in `launchdarkly/java-core` #135. Two .NET simplifications: no flush-failure restore path (.NET drops on send failure), and no `EventsConfiguration` constructor overload (it is a mutable property bag).

## Testing

- New `PerContextEventSummarizerTest` and `AggregatedEventSummarizerTest`; new per-context serialization assertion plus an aggregated-summary-has-no-context guard in `EventOutputTest`.
- Full suite passes (180 tests).

First of two sequential PRs; the second enables this in the .NET client SDK (SDK-2450).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics wire format and flush payload shape when `PerContextSummaries` is enabled; default-off preserves server behavior, but client enablement will increase summary event volume and attach PII-bearing contexts.
> 
> **Overview**
> Adds **opt-in per-context summary events** for Client-Side Summary Events (CSSE), while keeping server-side behavior unchanged by default.
> 
> Summarization is refactored behind **`IEventSummarizer`**: **`AggregatedEventSummarizer`** (single contextless summary, default) and **`PerContextEventSummarizer`** (one summary per evaluation context, with context attached). **`EventsConfiguration.PerContextSummaries`** (default `false`) picks the strategy in **`EventBuffer`**. **`EventSummarizer`** now uses **`GetSummaryAndReset()`** instead of **`Snapshot()`**, and **`EventSummary`** can carry an optional **`Context`**.
> 
> The flush path and **`EventOutputFormatter`** now handle **`IReadOnlyList<EventSummary>`**, emitting multiple summary events when needed and serializing **`context`** on summaries only when defined (with the same redaction as other events). Tests cover both summarizers, serialization, and the aggregated-no-context case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f645d4ddaf40770b513fe8449ecc4f3f93f3c274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->