### PR TITLE
feat: Update target frameworks to net8.0

### DIFF
--- a/.github/actions/build-release/action.yml
+++ b/.github/actions/build-release/action.yml
@@ -11,9 +11,7 @@ runs:
     - name: Setup dotnet build tools
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          6.0
-          7.0
+        dotnet-version: 8.0
 
     - name: Display dotnet version
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -11,9 +11,7 @@ runs:
     - name: Setup dotnet build tools
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          6.0
-          7.0
+        dotnet-version: 8.0
 
     - run: dotnet --version
       shell: bash

--- a/.github/actions/full-release/action.yml
+++ b/.github/actions/full-release/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: CI check
       uses: ./.github/actions/ci
       with:
-        framework_target: "net6.0"
+        framework_target: "net8.0"
 
     - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
       name: Get secrets

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -13,9 +13,7 @@ runs:
     - name: Setup dotnet build tools
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
-              6.0
-              7.0
+        dotnet-version: 8.0
 
     - name: Install Workloads
       shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,8 +15,7 @@ jobs:
     strategy:
       matrix:
         framework:
-          - { target: 'netcoreapp3.1', image: 'sdk:3.1-focal' }
-          - { target: 'net6.0', image: 'sdk:6.0-focal' }
+          - { target: 'net8.0', image: 'sdk:8.0' }
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/dotnet/${{ matrix.framework.image }}
     env:

--- a/src/LaunchDarkly.InternalSdk/Http/HttpProperties.cs
+++ b/src/LaunchDarkly.InternalSdk/Http/HttpProperties.cs
@@ -267,7 +267,7 @@ namespace LaunchDarkly.Sdk.Internal.Http
 
         private static HttpMessageHandler DefaultHttpMessageHandlerFactory(HttpProperties props)
         {
-#if NETCOREAPP || NET6_0
+#if NETCOREAPP
             return new SocketsHttpHandler
             {
                 ConnectTimeout = props.ConnectTimeout,

--- a/src/LaunchDarkly.InternalSdk/JsonConverterHelpers.cs
+++ b/src/LaunchDarkly.InternalSdk/JsonConverterHelpers.cs
@@ -185,7 +185,7 @@ namespace LaunchDarkly.Sdk.Internal
         /// <param name="reader">the JSON reader</param>
         /// <returns>an <see cref="ArrayHelper"/></returns>
         /// <exception cref="JsonException">if the next token is not the beginning of an array</exception>
-        public static ArrayHelper RequireArray(ref Utf8JsonReader reader) =>
+        public static ArrayHelper RequireArray(scoped ref Utf8JsonReader reader) =>
             new ArrayHelper(ref reader, false);
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace LaunchDarkly.Sdk.Internal
         /// <param name="reader">the JSON reader</param>
         /// <returns>an <see cref="ArrayHelper"/></returns>
         /// <exception cref="JsonException">if the next token is not the beginning of an array or null</exception>
-        public static ArrayHelper RequireArrayOrNull(ref Utf8JsonReader reader) =>
+        public static ArrayHelper RequireArrayOrNull(scoped ref Utf8JsonReader reader) =>
             new ArrayHelper(ref reader, true);
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace LaunchDarkly.Sdk.Internal
         /// <param name="reader">the JSON reader</param>
         /// <returns>an <see cref="ObjectHelper"/></returns>
         /// <exception cref="JsonException">if the next token is not the beginning of an object</exception>
-        public static ObjectHelper RequireObject(ref Utf8JsonReader reader)
+        public static ObjectHelper RequireObject(scoped ref Utf8JsonReader reader)
         {
             if (reader.TokenType == JsonTokenType.None)
             {
@@ -222,7 +222,7 @@ namespace LaunchDarkly.Sdk.Internal
         /// <param name="reader">the JSON reader</param>
         /// <returns>an <see cref="ObjectHelper"/></returns>
         /// <exception cref="JsonException">if the next token is not the beginning of an object or null</exception>
-        public static ObjectHelper RequireObjectOrNull(ref Utf8JsonReader reader)
+        public static ObjectHelper RequireObjectOrNull(scoped ref Utf8JsonReader reader)
         {
             if (reader.TokenType == JsonTokenType.None)
             {
@@ -245,7 +245,7 @@ namespace LaunchDarkly.Sdk.Internal
         {
             private readonly bool _empty;
 
-            internal ArrayHelper(ref Utf8JsonReader reader, bool allowNull)
+            internal ArrayHelper(scoped ref Utf8JsonReader reader, bool allowNull)
             {
                 if (reader.TokenType == JsonTokenType.None)
                 {
@@ -268,7 +268,7 @@ namespace LaunchDarkly.Sdk.Internal
             /// </summary>
             /// <param name="reader">the JSON reader (this must be passed again due to ref struct rules)</param>
             /// <returns>true if there is an element, false if this is the end</returns>
-            public bool Next(ref Utf8JsonReader reader) =>
+            public bool Next(scoped ref Utf8JsonReader reader) =>
                 !_empty && reader.Read() && reader.TokenType != JsonTokenType.EndArray;
         }
 
@@ -360,7 +360,7 @@ namespace LaunchDarkly.Sdk.Internal
             /// </summary>
             /// <param name="reader">the JSON reader (this must be passed again due to ref struct rules)</param>
             /// <returns>true if there is a property, false if this is the end</returns>
-            public bool Next(ref Utf8JsonReader reader)
+            public bool Next(scoped ref Utf8JsonReader reader)
             {
                 if (!_defined)
                 {

--- a/src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj
+++ b/src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj
@@ -8,12 +8,12 @@
       an environment variable is that we want to be able to run CI tests using .NET
       SDKs that may not support all of these target frameworks.
     -->
-    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp3.1;net462;net6.0</BuildFrameworks>
+    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;net462;net8.0</BuildFrameworks>
     <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LaunchDarkly.InternalSdk</AssemblyName>
     <OutputType>Library</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>11</LangVersion>
     <PackageId>LaunchDarkly.InternalSdk</PackageId>
     <RootNamespace>LaunchDarkly.Sdk.Internal</RootNamespace>
     <Description>LaunchDarkly internal common code for .NET and Xamarin clients</Description>
@@ -27,7 +27,7 @@
     <RepositoryBranch>main</RepositoryBranch>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
 

--- a/test/LaunchDarkly.InternalSdk.Tests/JsonConverterHelpersTest.cs
+++ b/test/LaunchDarkly.InternalSdk.Tests/JsonConverterHelpersTest.cs
@@ -184,7 +184,7 @@ namespace LaunchDarkly.Sdk.Internal
             VerifyNonEmptyArray(ref r2, ref a2);
         }
 
-        private void VerifyNonEmptyArray(ref Utf8JsonReader r, ref ArrayHelper a)
+        private void VerifyNonEmptyArray(scoped ref Utf8JsonReader r, ref ArrayHelper a)
         {
             Assert.True(a.Next(ref r));
             Assert.Equal(10, r.GetInt32());
@@ -207,7 +207,7 @@ namespace LaunchDarkly.Sdk.Internal
             VerifyEmptyArray(ref r2, ref a2);
         }
 
-        private void VerifyEmptyArray(ref Utf8JsonReader r, ref ArrayHelper a) =>
+        private void VerifyEmptyArray(scoped ref Utf8JsonReader r, ref ArrayHelper a) =>
             Assert.False(a.Next(ref r));
 
         [Fact]
@@ -242,7 +242,7 @@ namespace LaunchDarkly.Sdk.Internal
             VerifyNonEmptyObject(ref r2, ref o2);
         }
 
-        private void VerifyNonEmptyObject(ref Utf8JsonReader r, ref ObjectHelper o)
+        private void VerifyNonEmptyObject(scoped ref Utf8JsonReader r, ref ObjectHelper o)
         {
             Assert.True(o.Next(ref r));
             Assert.Equal("a", o.Name);
@@ -267,7 +267,7 @@ namespace LaunchDarkly.Sdk.Internal
             VerifyEmptyObject(ref r2, ref o2);
         }
 
-        private void VerifyEmptyObject(ref Utf8JsonReader r, ref ObjectHelper o) =>
+        private void VerifyEmptyObject(scoped ref Utf8JsonReader r, ref ObjectHelper o) =>
             Assert.False(o.Next(ref r));
 
         [Fact]

--- a/test/LaunchDarkly.InternalSdk.Tests/LaunchDarkly.InternalSdk.Tests.csproj
+++ b/test/LaunchDarkly.InternalSdk.Tests/LaunchDarkly.InternalSdk.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp3.1;net462;net6.0</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">net462;net8.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.InternalSdk.Tests</AssemblyName>
     <RootNamespace>LaunchDarkly.Sdk.Internal</RootNamespace>
+    <!-- Match the library's C# 11, needed for the 'scoped' ref-safety annotations. -->
+    <LangVersion>11</LangVersion>
     <Version>1.2.3</Version> <!-- we check for this value in tests -->
     <ReleaseVersion>1.2.3</ReleaseVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>


### PR DESCRIPTION
## Overview

Updates `dotnet-sdk-internal` to support **net8.0**, matching the target framework set used by the `dotnet-core` packages (`server-ai`, `telemetry`, `server`, `common`).

Resolves [SDK-1435](https://launchdarkly.atlassian.net/browse/SDK-1435).

**Target frameworks:** `netstandard2.0;netcoreapp3.1;net462;net6.0` → `netstandard2.0;net462;net8.0`

### Not a breaking change
Dropping `netcoreapp3.1` and `net6.0` does **not** warrant a major version bump:
- `netstandard2.0` and `net462` continue to cover .NET Framework consumers.
- `netcoreapp3.1` is not used by the consuming SDKs.
- Both dropped frameworks are out of support, and removing out-of-support TFMs is permitted without a major version.

## The CS8352/CS8350 problem (why this stalled previously)

The `JsonConverterHelpers` ref-struct helpers (`ArrayHelper`/`ObjectHelper`) could not be consumed under net8.0: the .NET 7+ runtime enables byref-field ref-safety analysis **regardless of `LangVersion`**, so the compiler assumed these ref structs might capture a reference to the `Utf8JsonReader` passed to their methods, producing `CS8350`/`CS8352` at every call site (including plain inline `Next(ref reader)` calls — so every downstream consumer would hit it on net8.0).

**Fix:** annotate the `Utf8JsonReader` parameters as `scoped` to declare that the helpers never capture a reference to the reader (which is true), and raise `LangVersion` to `11` so the annotation is available. `scoped` is a compile-time-only annotation — verified to build cleanly on `netstandard2.0` and `net462` as well. There is direct precedent: `dotnet-core`'s `server-ai` ships `LangVersion 11` with the identical TFM set.

## Other changes
- `HttpProperties`: simplified the handler guard `#if NETCOREAPP || NET6_0` → `#if NETCOREAPP` (the branch selects `SocketsHttpHandler`, available on all .NET Core 2.1+/.NET 5+ targets, so no version floor applies; the `|| NET6_0` clause was redundant).
- CI and release actions updated to install the 8.0 SDK and target net8.0.

## Testing
- **net8.0:** 180/180 unit tests pass.
- **netstandard2.0** and **net462:** build clean.
- No tests were removed or disabled.

[SDK-1435]: https://launchdarkly.atlassian.net/browse/SDK-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> TFM matrix changes can affect consumers that targeted net6.0/netcoreapp3.1 directly; public helper signatures changed to scoped ref, which downstream code must compile against on modern runtimes.
> 
> **Overview**
> Aligns **LaunchDarkly.InternalSdk** with the **dotnet-core** TFM set by moving the modern target from **net6.0** / **netcoreapp3.1** to **net8.0** while keeping **netstandard2.0** and **net462**. Default build/test frameworks and GitHub Actions (**setup-dotnet** 8.0, CI matrix, full release **framework_target**) are updated accordingly; **LangVersion** is raised to **11**.
> 
> **JsonConverterHelpers** `ArrayHelper` / `ObjectHelper` APIs now use **`scoped ref Utf8JsonReader`** so net8.0 ref-safety analysis (**CS8350** / **CS8352**) passes without changing runtime behavior. Tests mirror those signatures.
> 
> **HttpProperties** uses **`#if NETCOREAPP`** only (drops redundant **NET6_0**). **System.Collections.Immutable** is no longer pulled in for the removed **netcoreapp3.1** TFM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74fefad2ad70e6a65bbededca38e285b61d84124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->