### PR TITLE
feat: Update target frameworks to net8.0 (demote ref struct)

### DIFF
--- a/.github/actions/build-release/action.yml
+++ b/.github/actions/build-release/action.yml
@@ -11,9 +11,7 @@ runs:
     - name: Setup dotnet build tools
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          6.0
-          7.0
+        dotnet-version: 8.0
 
     - name: Display dotnet version
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -11,9 +11,7 @@ runs:
     - name: Setup dotnet build tools
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          6.0
-          7.0
+        dotnet-version: 8.0
 
     - run: dotnet --version
       shell: bash

--- a/.github/actions/full-release/action.yml
+++ b/.github/actions/full-release/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: CI check
       uses: ./.github/actions/ci
       with:
-        framework_target: "net6.0"
+        framework_target: "net8.0"
 
     - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
       name: Get secrets

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -13,9 +13,7 @@ runs:
     - name: Setup dotnet build tools
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
-              6.0
-              7.0
+        dotnet-version: 8.0
 
     - name: Install Workloads
       shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,8 +15,7 @@ jobs:
     strategy:
       matrix:
         framework:
-          - { target: 'netcoreapp3.1', image: 'sdk:3.1-focal' }
-          - { target: 'net6.0', image: 'sdk:6.0-focal' }
+          - { target: 'net8.0', image: 'sdk:8.0' }
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/dotnet/${{ matrix.framework.image }}
     env:

--- a/src/LaunchDarkly.InternalSdk/Http/HttpProperties.cs
+++ b/src/LaunchDarkly.InternalSdk/Http/HttpProperties.cs
@@ -267,7 +267,7 @@ namespace LaunchDarkly.Sdk.Internal.Http
 
         private static HttpMessageHandler DefaultHttpMessageHandlerFactory(HttpProperties props)
         {
-#if NETCOREAPP || NET6_0
+#if NETCOREAPP
             return new SocketsHttpHandler
             {
                 ConnectTimeout = props.ConnectTimeout,

--- a/src/LaunchDarkly.InternalSdk/JsonConverterHelpers.cs
+++ b/src/LaunchDarkly.InternalSdk/JsonConverterHelpers.cs
@@ -241,7 +241,7 @@ namespace LaunchDarkly.Sdk.Internal
         /// </summary>
         /// <seealso cref="RequireArray(ref Utf8JsonReader)"/>
         /// <seealso cref="RequireArrayOrNull(ref Utf8JsonReader)"/>
-        public ref struct ArrayHelper
+        public struct ArrayHelper
         {
             private readonly bool _empty;
 
@@ -285,7 +285,7 @@ namespace LaunchDarkly.Sdk.Internal
         /// </code></example>
         /// <seealso cref="RequireObject(ref Utf8JsonReader)"/>
         /// <seealso cref="RequireObjectOrNull(ref Utf8JsonReader)"/>
-        public ref struct ObjectHelper
+        public struct ObjectHelper
         {
             private readonly bool _defined;
             private readonly string[] _requiredPropertyNames;

--- a/src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj
+++ b/src/LaunchDarkly.InternalSdk/LaunchDarkly.InternalSdk.csproj
@@ -8,7 +8,7 @@
       an environment variable is that we want to be able to run CI tests using .NET
       SDKs that may not support all of these target frameworks.
     -->
-    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp3.1;net462;net6.0</BuildFrameworks>
+    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;net462;net8.0</BuildFrameworks>
     <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LaunchDarkly.InternalSdk</AssemblyName>
@@ -27,7 +27,7 @@
     <RepositoryBranch>main</RepositoryBranch>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
 

--- a/test/LaunchDarkly.InternalSdk.Tests/LaunchDarkly.InternalSdk.Tests.csproj
+++ b/test/LaunchDarkly.InternalSdk.Tests/LaunchDarkly.InternalSdk.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp3.1;net462;net6.0</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">net462;net8.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.InternalSdk.Tests</AssemblyName>
     <RootNamespace>LaunchDarkly.Sdk.Internal</RootNamespace>


### PR DESCRIPTION
## Overview

Updates `dotnet-sdk-internal` to support **net8.0**. This is the **alternative** to #69 — same framework change, but it resolves the ref-safety problem **without changing the C# language version** (stays at C# 7.3 on every target framework).

Resolves [SDK-1435](https://launchdarkly.atlassian.net/browse/SDK-1435).

**Target frameworks:** `netstandard2.0;netcoreapp3.1;net462;net6.0` → `netstandard2.0;net462;net8.0`

### Not a breaking change
Dropping `netcoreapp3.1` and `net6.0` does not warrant a major version bump: `netstandard2.0`/`net462` continue to cover .NET Framework consumers, `netcoreapp3.1` is not used by the consuming SDKs, and both dropped frameworks are out of support.

## The fix: demote the helpers from `ref struct` to `struct`

Under net8.0 the .NET 7+ runtime enables byref-field ref-safety analysis (independent of `LangVersion`), so the compiler assumes the `ArrayHelper`/`ObjectHelper` ref structs *might* capture a reference to the `Utf8JsonReader` passed to their methods, producing `CS8350`/`CS8352` at every call site.

Rather than annotate the reader parameters `scoped` (which requires raising `LangVersion` to 11 — see #69), this PR **demotes `ArrayHelper` and `ObjectHelper` to plain `struct`s**:

- They hold **no `Span` or `ref`-struct fields** (`bool`, `string[]`, `string`, `UInt64`, `SequencePosition?`), so they never needed to be ref structs. The marking was inherited from the `LaunchDarkly.JsonStream` `ArrayReader`/`ObjectReader` this code was ported from in 3.0.0, where the readers genuinely held `Span`/ref-struct fields.
- A non-ref struct isn't subject to ref-field-capture analysis, so the errors disappear and the project **stays at C# 7.3** — no `LangVersion` override on any TFM, fully within Microsoft's supported language-version model.

### Compatibility
`ref struct` → `struct` is a **relaxation** and is source/binary-compatible: every valid use of the ref structs is still valid for plain structs. All consumer usages in `dotnet-core` follow the `for (var x = RequireObject(ref r); x.Next(ref r);)` local-variable pattern — none store, return, box, or capture the helpers — so they recompile unchanged. The trade-off vs #69 is that the compiler no longer prevents misuse (boxing / field storage / closure capture) of the now-mutable-struct `ObjectHelper`.

## Other changes
- `HttpProperties`: simplified the handler guard `#if NETCOREAPP || NET6_0` → `#if NETCOREAPP` (`SocketsHttpHandler` exists on all .NET Core 2.1+/.NET 5+ targets; no version floor, and the `|| NET6_0` clause was redundant).
- CI and release actions updated to install the 8.0 SDK and target net8.0.

## Testing
- **net8.0:** 180/180 unit tests pass.
- **netstandard2.0** and **net462:** build clean.
- No tests removed, disabled, or modified (the test file is byte-identical to `main`).

## Comparison with #69
| | #69 (`scoped` + LangVersion 11) | This PR (demote to `struct`) |
|---|---|---|
| C# language version | raised to 11 (net462/netstandard2.0 above their default → "unsupported" per MS) | unchanged at 7.3 (supported on all TFMs) |
| Public API | unchanged — keeps `ref struct` + stack-only guardrails | `ref struct` → `struct` (relaxation; loses misuse guardrails) |
| Files changed | 10 | 9 |

[SDK-1435]: https://launchdarkly.atlassian.net/browse/SDK-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ